### PR TITLE
Applying changes to get up to date with GridServer changes

### DIFF
--- a/lib/capistrano/tasks/gridserver.rake
+++ b/lib/capistrano/tasks/gridserver.rake
@@ -9,7 +9,7 @@ namespace :gridserver do
       # Only change current symlink if NEW deploy
       unless release_path == current_path
         info "Removing absolute current symlink"
-        execute "rm -d #{current_path}"
+        execute "unlink #{current_path}"
 
         info "Creating relative current symlink"
         execute "cd #{fetch(:deploy_to)} && ln -s ./releases/#{File.basename release_path} current"
@@ -27,6 +27,16 @@ namespace :gridserver do
             execute :rm, '-rf', target
           end
           execute :ln, '-s', relative, target
+        end
+      end
+      next unless any? :linked_files
+      on release_roles :all do
+        fetch(:linked_files).each do |dir|
+          target = release_path.join(dir)
+          source = shared_path.join(dir)
+          relative = Pathname.new('../' * (dir.count('/') + 2)).join('shared').join(dir) # 2 for releases/timestamp
+          # added f flag to remove if exists
+          execute :ln, '-sf', relative, target
         end
       end
     end


### PR DESCRIPTION
Hi Craig,

Thanks for this gem. This pull request applies changes provided by @sharpdot in his gist, in this issue:

[Grid no longer supports the `-d` flag](https://github.com/morrislaptop/capistrano-gridserver/issues/5)

I'm still learning Ruby and Capistrano, so I'm not sure if there is a more elegant way to accomplish these changes, but they work for me. If you have any questions, maybe post them to the issue linked above and tag me and/or @sharpdot.

Thanks, and best regards,

@davidham

P.S. Many thanks to @sharpdot for the fix, this saved my bacon!
